### PR TITLE
Fix plugin resources import to avoid cross-plugin conflict

### DIFF
--- a/joinmultiplelines.py
+++ b/joinmultiplelines.py
@@ -57,8 +57,8 @@ from qgis.gui import QgsMessageBar
 # initialize Qt resources from file resouces.py
 import sys
 import os.path
-sys.path.append(os.path.dirname(__file__))
-import resources
+
+from . import resources
 
 class joinmultiplelines:
     def __init__(self, iface):


### PR DESCRIPTION
This fixes a crash on QGIS 3.40 / Python 3.12 caused by a global `import resources`, which could load another plugin's resources.py.

The fix replaces it with a proper relative import to avoids cross-plugin Qt resource collisions.
